### PR TITLE
security: Harden token encryption with random salt and remove debug logging

### DIFF
--- a/src/auth/tokenManager.ts
+++ b/src/auth/tokenManager.ts
@@ -28,7 +28,13 @@ export class TokenManager {
     if (this.saltPath) {
       try {
         return await fs.readFile(this.saltPath);
-      } catch {
+      } catch (error: unknown) {
+        if (
+          error instanceof Error &&
+          (error as NodeJS.ErrnoException).code !== 'ENOENT'
+        ) {
+          throw error;
+        }
         const salt = crypto.randomBytes(32);
         const dir = path.dirname(this.saltPath);
         await fs.mkdir(dir, { recursive: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,11 +294,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       // Temporarily store token to fetch company list
       await tokenManager.setToken(0, tokenResponse);
-      const companies = await freeeClient.getCompanies();
-      await tokenManager.removeToken(0);
-
-      for (const company of companies) {
-        await tokenManager.setToken(company.id, tokenResponse);
+      let companies;
+      try {
+        companies = await freeeClient.getCompanies();
+        for (const company of companies) {
+          await tokenManager.setToken(company.id, tokenResponse);
+        }
+      } finally {
+        await tokenManager.removeToken(0);
       }
 
       return {


### PR DESCRIPTION
## Summary

- Replace hardcoded `'salt'` string with `crypto.randomBytes(32)` per installation, stored in `tokens.enc.salt` with `0600` permissions
- Add automatic migration from legacy salt to random salt on token load
- Remove all `/tmp/freee-mcp-debug.log` writes and simplify `freee_get_access_token` handler (~95 → ~15 lines)
- Add startup warning when `FREEE_TOKEN_ENCRYPTION_KEY` is not set

Closes #56

## Changes

### `src/auth/tokenManager.ts`
- **New**: `loadOrCreateSalt()` — generates random 32-byte salt, stores in `.salt` file with `0600` permissions
- **New**: `deriveKey()` — derives encryption key from secret + salt via scrypt
- **New**: `decryptWithKey()` — decrypts with a specific key (used for migration)
- **Modified**: `loadTokens()` — initializes salt, attempts current salt decryption, falls back to legacy `'salt'` migration
- **Modified**: `saveTokens()` — safety check ensures encryption key is initialized
- **Modified**: Constructor — defers key derivation to `loadTokens()`/`saveTokens()`

### `src/index.ts`
- **Removed**: `import { promises as fs } from 'fs'` (no longer needed)
- **Removed**: All 4 `/tmp/freee-mcp-debug.log` write blocks
- **Removed**: ~80 lines of verbose emoji debug logging in `freee_get_access_token`
- **Added**: Encryption key warning at startup

## Security Review

- AES-256-GCM with random IV per encryption ✅
- scrypt key derivation with random 32-byte salt ✅
- Salt file stored with 0600 permissions ✅
- No sensitive data written to logs or temp files ✅
- Backward-compatible migration from legacy tokens ✅

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors, 14 pre-existing warnings)
- [x] `npm test` passes (42/42 tests)
- [x] `npm run build` succeeds
- [x] Pre-commit hooks pass (ESLint, TypeScript, gitleaks)
- [ ] Verify salt file creation on fresh install
- [ ] Verify legacy token migration works with existing `tokens.enc`
- [ ] Verify encryption key warning appears when `FREEE_TOKEN_ENCRYPTION_KEY` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)