### PR TITLE
fix(auth): use TokenManager for encrypted token storage in setup-auth

### DIFF
--- a/scripts/setup-auth.js
+++ b/scripts/setup-auth.js
@@ -5,7 +5,7 @@ import { spawn } from "child_process";
 import axios from "axios";
 import fs from "fs/promises";
 import path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import dotenv from "dotenv";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -24,7 +24,7 @@ try {
   process.exit(1);
 }
 
-const { TokenManager } = await import(tokenManagerPath);
+const { TokenManager } = await import(pathToFileURL(tokenManagerPath).href);
 
 // Load .env file
 dotenv.config();
@@ -223,7 +223,7 @@ async function main() {
             // File doesn't exist
           }
 
-          if (!existingEnv.includes("FREEE_CLIENT_ID")) {
+          if (!/^FREEE_CLIENT_ID=/m.test(existingEnv)) {
             await fs.appendFile(envPath, envContent);
             console.log("✅ Credentials saved to .env file");
           }


### PR DESCRIPTION
## Summary

- **Fix**: `scripts/setup-auth.js` was writing plain JSON tokens to `tokens.json`, but `TokenManager` expects AES-256-GCM encrypted data at `tokens.enc` — making tokens saved during setup invisible to the server on startup
- **Solution**: Dynamically import compiled `TokenManager` from `dist/` and use its encrypted storage APIs (`setToken()`, `loadTokens()`, `getDefaultStoragePath()`)
- **Tests**: Added 22 unit tests covering all acceptance criteria (100% coverage for fix type)

## Changes

### `scripts/setup-auth.js`
- Replace static import with dynamic import of `TokenManager` from `dist/auth/tokenManager.js`
- Add build guard that checks for compiled output before proceeding (clear error: "Run npm run build first")
- Use `TokenManager.getDefaultStoragePath()` for platform-specific encrypted storage path (`tokens.enc`)
- Use `tokenManager.loadTokens()` + `getAllCompanyIds()` for existing token detection
- Use `tokenManager.setToken()` for encrypted writes instead of `fs.writeFile()` with plain JSON
- Add warning message when token loading fails (e.g., wrong encryption key)

### `src/__tests__/scripts/setup-auth.test.ts` (new)
- 22 tests: source code correctness, build guard behavior, path compatibility, encryption round-trip

## Acceptance Criteria

- [x] Tokens saved via setup-auth are encrypted and readable by server
- [x] Default storage path matches `TokenManager.getDefaultStoragePath()`
- [x] Clear error when `dist/` directory doesn't exist
- [x] Existing encrypted tokens detected and prompted for reuse

## Test plan

- [x] All 72 tests pass (50 existing + 22 new)
- [x] Build guard verified: shows friendly error when `dist/` missing
- [x] Syntax check passes (`node --check`)
- [x] Lint, typecheck, build all pass
- [x] Encryption round-trip test: write via `setToken`, read via `loadTokens`
- [ ] [manual] End-to-end OAuth flow with real freee credentials
- [ ] [manual] Verify server reads tokens saved by setup-auth

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)