### PR TITLE
feat(api): add segment tags for department/project analysis

### DIFF
--- a/src/__tests__/api/freeeClient.test.ts
+++ b/src/__tests__/api/freeeClient.test.ts
@@ -360,6 +360,54 @@ describe('FreeeClient', () => {
         });
         expect(result).toEqual(mockTags);
       });
+
+      it('should fetch segment tags', async () => {
+        const mockSegmentTags = [
+          { id: 1, name: 'Department A', description: 'Main dept' },
+          { id: 2, name: 'Department B' },
+        ];
+
+        mockAxiosInstance.get.mockResolvedValue({
+          data: { segment_tags: mockSegmentTags },
+        });
+
+        const result = await client.getSegmentTags(123, 1, {
+          offset: 0,
+          limit: 50,
+        });
+
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith('/segments/1/tags', {
+          params: { company_id: 123, offset: 0, limit: 50 },
+        });
+        expect(result).toEqual(mockSegmentTags);
+      });
+
+      it('should create a segment tag', async () => {
+        const mockSegmentTag = {
+          id: 1,
+          name: 'New Department',
+          description: 'A new department',
+        };
+
+        mockAxiosInstance.post.mockResolvedValue({
+          data: { segment_tag: mockSegmentTag },
+        });
+
+        const result = await client.createSegmentTag(123, 2, {
+          name: 'New Department',
+          description: 'A new department',
+        });
+
+        expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+          '/segments/2/tags',
+          {
+            company_id: 123,
+            name: 'New Department',
+            description: 'A new department',
+          },
+        );
+        expect(result).toEqual(mockSegmentTag);
+      });
     });
 
     describe('authentication methods', () => {

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -73,6 +73,8 @@ describe('MCP Tool Handlers', () => {
         'GetPartnersSchema',
         'GetSectionsSchema',
         'GetTagsSchema',
+        'GetSegmentTagsSchema',
+        'CreateSegmentTagSchema',
         'GetProfitLossSchema',
         'GetBalanceSheetSchema',
         'GetTrialBalanceSchema',

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -90,8 +90,8 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
       toolNames.push(match[1]);
     }
 
-    it('should register exactly 31 tools via registerTool()', () => {
-      expect(toolNames).toHaveLength(31);
+    it('should register exactly 33 tools via registerTool()', () => {
+      expect(toolNames).toHaveLength(33);
     });
 
     it('should register all expected tool names', () => {
@@ -110,6 +110,8 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
         'freee_get_sections',
         'freee_get_tags',
         'freee_get_tax_codes',
+        'freee_get_segment_tags',
+        'freee_create_segment_tag',
         'freee_get_invoices',
         'freee_create_invoice',
         'freee_search_deals',
@@ -154,7 +156,7 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
           (block.includes('\'freee_') || block.includes('"freee_')),
       );
 
-      expect(toolCalls.length).toBe(31);
+      expect(toolCalls.length).toBe(33);
       toolCalls.forEach((block) => {
         expect(block).toContain('description:');
       });
@@ -181,6 +183,8 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
         'schemas.GetSectionsSchema',
         'schemas.GetTagsSchema',
         'schemas.GetTaxCodesSchema',
+        'schemas.GetSegmentTagsSchema',
+        'schemas.CreateSegmentTagSchema',
         'schemas.GetInvoicesSchema',
         'schemas.CreateInvoiceSchema',
         'schemas.GetTrialBalanceSchema',
@@ -363,7 +367,7 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
 });
 
 describe('Schema Structure Verification', () => {
-  it('should export all 31 schemas as raw shapes (plain objects)', async () => {
+  it('should export all 33 schemas as raw shapes (plain objects)', async () => {
     const schemas = await import('../schemas.js');
 
     const schemaNames = [
@@ -380,6 +384,9 @@ describe('Schema Structure Verification', () => {
       'CreatePartnerSchema',
       'GetSectionsSchema',
       'GetTagsSchema',
+      'GetTaxCodesSchema',
+      'GetSegmentTagsSchema',
+      'CreateSegmentTagSchema',
       'GetInvoicesSchema',
       'CreateInvoiceSchema',
       'SearchDealsSchema',
@@ -397,7 +404,6 @@ describe('Schema Structure Verification', () => {
       'ComparePeriodsSchema',
       'MonthlyTrendsSchema',
       'CashPositionSchema',
-      'GetTaxCodesSchema',
     ];
 
     schemaNames.forEach((name) => {
@@ -419,7 +425,7 @@ describe('Schema Structure Verification', () => {
     ).toBeUndefined();
   });
 
-  it('should export exactly 31 schemas', async () => {
+  it('should export exactly 33 schemas', async () => {
     const schemas = await import('../schemas.js');
 
     // Count exports that end with 'Schema'
@@ -427,7 +433,7 @@ describe('Schema Structure Verification', () => {
       key.endsWith('Schema'),
     );
 
-    expect(schemaExports).toHaveLength(31);
+    expect(schemaExports).toHaveLength(33);
   });
 
   it('should use Zod types in schema fields', async () => {

--- a/src/api/freeeClient.ts
+++ b/src/api/freeeClient.ts
@@ -22,6 +22,7 @@ import {
   FreeePartner,
   FreeeSection,
   FreeeTag,
+  FreeeSegmentTag,
   FreeeInvoice,
   FreeeTrialBalance,
   FreeeTrialBalanceItem,
@@ -569,6 +570,51 @@ export class FreeeClient {
     );
     this.cache.set(cacheKey, response.data.taxes, CACHE_TTL_TAX_CODES);
     return response.data.taxes;
+  }
+
+  // Segment Tag methods
+  async getSegmentTags(
+    companyId: number,
+    segmentId: 1 | 2 | 3,
+    params?: {
+      offset?: number;
+      limit?: number;
+    },
+  ): Promise<FreeeSegmentTag[]> {
+    const cacheKey = generateCacheKey(
+      companyId,
+      `segment_${segmentId}_tags`,
+      params,
+    );
+    const cached = this.cache.get<FreeeSegmentTag[]>(cacheKey);
+    if (cached) return cached;
+
+    const response = await this.api.get<{ segment_tags: FreeeSegmentTag[] }>(
+      `/segments/${segmentId}/tags`,
+      {
+        params: { company_id: companyId, ...params },
+      },
+    );
+    this.cache.set(cacheKey, response.data.segment_tags, CACHE_TTL_TAGS);
+    return response.data.segment_tags;
+  }
+
+  async createSegmentTag(
+    companyId: number,
+    segmentId: 1 | 2 | 3,
+    tag: {
+      name: string;
+      description?: string;
+      shortcut1?: string;
+      shortcut2?: string;
+    },
+  ): Promise<FreeeSegmentTag> {
+    const response = await this.api.post<{ segment_tag: FreeeSegmentTag }>(
+      `/segments/${segmentId}/tags`,
+      { company_id: companyId, ...tag },
+    );
+    this.cache.invalidate(`${companyId}:segment_${segmentId}_tags`);
+    return response.data.segment_tag;
   }
 
   // Invoice methods

--- a/src/api/responseFormatter.ts
+++ b/src/api/responseFormatter.ts
@@ -5,6 +5,7 @@ import type {
   FreeeAccountItem,
   FreeeSection,
   FreeeTag,
+  FreeeSegmentTag,
   FreeeWalletable,
   FreeeManualJournal,
   FreeeTaxCode,
@@ -18,6 +19,7 @@ import type {
   FormattedSection,
   FormattedTag,
   FormattedTaxCode,
+  FormattedSegmentTag,
   FormattedWalletable,
   FormattedManualJournal,
   FormattedManualJournalDetail,
@@ -232,6 +234,27 @@ export class ResponseFormatter {
       return { summary, items: [] };
     }
     return { summary, items: tags.map((t) => this.formatTag(t)) };
+  }
+
+  // Segment Tag formatting
+  static formatSegmentTag(tag: FreeeSegmentTag): FormattedSegmentTag {
+    return stripEmpty({
+      id: tag.id,
+      name: tag.name,
+      description: tag.description,
+      shortcut1: tag.shortcut1,
+    }) as FormattedSegmentTag;
+  }
+
+  static formatSegmentTags(
+    tags: FreeeSegmentTag[],
+    compact?: boolean,
+  ): FormattedListResponse<FormattedSegmentTag> {
+    const summary: ListSummary = { total_count: tags.length };
+    if (compact) {
+      return { summary, items: [] };
+    }
+    return { summary, items: tags.map((t) => this.formatSegmentTag(t)) };
   }
 
   // Walletable formatting

--- a/src/index.ts
+++ b/src/index.ts
@@ -596,6 +596,66 @@ registerTool(
   },
 );
 
+// === Segment Tag tools ===
+
+registerTool(
+  'freee_get_segment_tags',
+  {
+    description:
+      'Get list of segment tags (セグメントタグ) for multi-axis analysis - Retrieves segment tags (タグ1-3) used for department/project tracking. Use with profit_loss breakdown for segment-based P&L analysis. Requires paid freee plan. Different from regular tags (freee_get_tags): segment tags enable up to 3 independent classification axes.',
+    inputSchema: schemas.GetSegmentTagsSchema,
+  },
+  async ({ companyId, segmentId, offset, limit, compact }) => {
+    try {
+      const tags = await freeeClient.getSegmentTags(
+        getCompanyId(companyId),
+        segmentId,
+        { offset, limit },
+      );
+      const formatted = ResponseFormatter.formatSegmentTags(tags, compact);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(formatted, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      handleToolError('freee_get_segment_tags', error);
+    }
+  },
+);
+
+registerTool(
+  'freee_create_segment_tag',
+  {
+    description:
+      'Create a new segment tag (セグメントタグ) - Creates a tag under segment 1-3 for department/project classification. Requires paid freee plan.',
+    inputSchema: schemas.CreateSegmentTagSchema,
+  },
+  async ({ companyId, segmentId, name, description, shortcut1, shortcut2 }) => {
+    try {
+      const tag = await freeeClient.createSegmentTag(
+        getCompanyId(companyId),
+        segmentId,
+        { name, description, shortcut1, shortcut2 },
+      );
+      const formatted = ResponseFormatter.formatSegmentTag(tag);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(formatted, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      handleToolError('freee_create_segment_tag', error);
+    }
+  },
+);
+
 // === Invoice tools ===
 
 registerTool(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -149,6 +149,38 @@ export const GetTagsSchema = {
     ),
 };
 
+// Segment Tag schemas
+export const GetSegmentTagsSchema = {
+  companyId: companyIdField,
+  segmentId: z
+    .union([z.literal(1), z.literal(2), z.literal(3)])
+    .describe('Segment number (1-3): タグ1, タグ2, タグ3'),
+  offset: z.number().optional().describe('Pagination offset'),
+  limit: z
+    .number()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe('Number of results (1-100)'),
+  compact: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, returns summary statistics only without individual records. Useful for quick overviews.',
+    ),
+};
+
+export const CreateSegmentTagSchema = {
+  companyId: companyIdField,
+  segmentId: z
+    .union([z.literal(1), z.literal(2), z.literal(3)])
+    .describe('Segment number (1-3): タグ1, タグ2, タグ3'),
+  name: z.string().describe('Segment tag name'),
+  description: z.string().optional().describe('Description'),
+  shortcut1: z.string().optional().describe('Shortcut 1'),
+  shortcut2: z.string().optional().describe('Shortcut 2'),
+};
+
 // Invoice schemas
 export const GetInvoicesSchema = {
   companyId: companyIdField,

--- a/src/types/freee.ts
+++ b/src/types/freee.ts
@@ -78,6 +78,16 @@ export interface FreeeTag {
   available: boolean;
 }
 
+export interface FreeeSegmentTag {
+  id: number;
+  company_id: number;
+  name: string;
+  description?: string;
+  shortcut1?: string;
+  shortcut2?: string;
+  available: boolean;
+}
+
 export interface FreeeInvoice {
   id: number;
   company_id: number;
@@ -269,6 +279,13 @@ export interface FormattedTaxCode {
   code: number;
   name: string;
   name_ja: string;
+}
+
+export interface FormattedSegmentTag {
+  id: number;
+  name: string;
+  description?: string;
+  shortcut1?: string;
 }
 
 export interface FormattedWalletable {


### PR DESCRIPTION
## Summary

- Add `freee_get_segment_tags` and `freee_create_segment_tag` MCP tools for freee API segment tag endpoints
- Segment tags provide up to 3 independent classification axes (タグ1-3) for multi-axis department/project analysis
- Follow existing patterns: types → schemas → client → formatters → tool registration → tests

Closes #97

## Changes

| File | Change |
|------|--------|
| `src/types/freee.ts` | `FreeeSegmentTag` and `FormattedSegmentTag` types |
| `src/schemas.ts` | `GetSegmentTagsSchema` and `CreateSegmentTagSchema` |
| `src/api/freeeClient.ts` | `getSegmentTags()` and `createSegmentTag()` with TTL cache |
| `src/api/responseFormatter.ts` | `formatSegmentTag()` and `formatSegmentTags()` |
| `src/index.ts` | Tool registration for both new tools |
| `src/__tests__/` | Comprehensive tests (298 total, all passing) |

## Test plan

- [x] All 298 tests pass (`npm test`)
- [x] TypeScript compiles cleanly (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] No scope creep — only segment tag related changes
- [x] No security issues detected (gitleaks, no secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)