### PR TITLE
feat(api): add journals endpoint for monthly closing verification

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -90,8 +90,8 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
       toolNames.push(match[1]);
     }
 
-    it('should register exactly 39 tools via registerTool()', () => {
-      expect(toolNames).toHaveLength(39);
+    it('should register exactly 40 tools via registerTool()', () => {
+      expect(toolNames).toHaveLength(40);
     });
 
     it('should register all expected tool names', () => {
@@ -135,6 +135,7 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
         'freee_monthly_trends',
         'freee_cash_position',
         'freee_create_manual_journal',
+        'freee_get_journals',
       ];
 
       expectedToolNames.forEach((name) => {
@@ -162,7 +163,7 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
           (block.includes('\'freee_') || block.includes('"freee_')),
       );
 
-      expect(toolCalls.length).toBe(39);
+      expect(toolCalls.length).toBe(40);
       toolCalls.forEach((block) => {
         expect(block).toContain('description:');
       });
@@ -211,6 +212,7 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
         'schemas.GetExpenseApplicationsSchema',
         'schemas.GetExpenseApplicationSchema',
         'schemas.ApproveExpenseApplicationSchema',
+        'schemas.GetJournalsSchema',
       ];
 
       schemaUsages.forEach((usage) => {
@@ -379,7 +381,7 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
 });
 
 describe('Schema Structure Verification', () => {
-  it('should export all 39 schemas as raw shapes (plain objects)', async () => {
+  it('should export all 40 schemas as raw shapes (plain objects)', async () => {
     const schemas = await import('../schemas.js');
 
     const schemaNames = [
@@ -422,6 +424,7 @@ describe('Schema Structure Verification', () => {
       'MonthlyTrendsSchema',
       'CashPositionSchema',
       'CreateManualJournalSchema',
+      'GetJournalsSchema',
     ];
 
     schemaNames.forEach((name) => {
@@ -443,7 +446,7 @@ describe('Schema Structure Verification', () => {
     ).toBeUndefined();
   });
 
-  it('should export exactly 39 schemas', async () => {
+  it('should export exactly 40 schemas', async () => {
     const schemas = await import('../schemas.js');
 
     // Count exports that end with 'Schema'
@@ -451,7 +454,7 @@ describe('Schema Structure Verification', () => {
       key.endsWith('Schema'),
     );
 
-    expect(schemaExports).toHaveLength(39);
+    expect(schemaExports).toHaveLength(40);
   });
 
   it('should use Zod types in schema fields', async () => {

--- a/src/api/freeeClient.ts
+++ b/src/api/freeeClient.ts
@@ -34,6 +34,9 @@ import {
   FreeeTaxCode,
   FreeeTransfer,
   FreeeExpenseApplication,
+  FreeeJournalDownloadRequest,
+  FreeeJournalDownloadStatus,
+  FreeeJournalEntry,
   FreeeApiError,
   DealAggregation,
   PartnerAggregation,
@@ -1536,6 +1539,203 @@ export class FreeeClient {
 
     if (cv > 0.2) return 'fluctuating';
     return 'stable';
+  }
+
+  // Journal download methods (async API)
+  // Flow: 1) Request download → 2) Poll status → 3) Download CSV → 4) Parse entries
+  private static readonly JOURNAL_POLL_INTERVAL_MS = 3000;
+  private static readonly JOURNAL_POLL_MAX_ATTEMPTS = 40; // 120 seconds max
+
+  async getJournals(
+    companyId: number,
+    params: {
+      start_date: string;
+      end_date: string;
+      visible_tags?: string[];
+      visible_ids?: string[];
+    },
+  ): Promise<FreeeJournalEntry[]> {
+    // Step 1: Request download (returns 202)
+    logClient(
+      'Requesting journal download for company %d (%s to %s)',
+      companyId,
+      params.start_date,
+      params.end_date,
+    );
+
+    const downloadReq = await this.api.get<{
+      journals: FreeeJournalDownloadRequest;
+    }>('/journals', {
+      params: {
+        company_id: companyId,
+        download_type: 'generic',
+        start_date: params.start_date,
+        end_date: params.end_date,
+        'visible_tags[]': params.visible_tags ?? ['all'],
+        'visible_ids[]': params.visible_ids,
+      },
+      // freee returns 202 Accepted — axios treats 2xx as success
+    });
+
+    const reportId = downloadReq.data.journals.id;
+    logClient('Journal download request accepted: id=%d', reportId);
+
+    // Step 2: Poll status until uploaded or failed
+    let downloadUrl: string | undefined;
+    for (
+      let attempt = 0;
+      attempt < FreeeClient.JOURNAL_POLL_MAX_ATTEMPTS;
+      attempt++
+    ) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, FreeeClient.JOURNAL_POLL_INTERVAL_MS),
+      );
+
+      const statusResp = await this.api.get<{
+        journals: FreeeJournalDownloadStatus;
+      }>(`/journals/reports/${reportId}/status`, {
+        params: { company_id: companyId },
+      });
+
+      const { status } = statusResp.data.journals;
+      logClient(
+        'Journal download status: %s (attempt %d)',
+        status,
+        attempt + 1,
+      );
+
+      if (status === 'uploaded') {
+        downloadUrl = statusResp.data.journals.download_url;
+        break;
+      }
+      if (status === 'failed') {
+        throw new Error(
+          'Journal download failed on freee server. Please try again later.',
+        );
+      }
+      // enqueued or working → continue polling
+    }
+
+    if (!downloadUrl) {
+      throw new Error(
+        `Journal download timed out after ${(FreeeClient.JOURNAL_POLL_MAX_ATTEMPTS * FreeeClient.JOURNAL_POLL_INTERVAL_MS) / 1000} seconds. The data may be too large or the server is busy.`,
+      );
+    }
+
+    // Step 3: Download CSV
+    logClient('Downloading journal CSV from %s', downloadUrl);
+    const csvResp = await this.api.get<string>(
+      `/journals/reports/${reportId}/download`,
+      {
+        params: { company_id: companyId },
+        responseType: 'text',
+        headers: { Accept: 'text/csv' },
+      },
+    );
+
+    // Step 4: Parse CSV into structured entries
+    return FreeeClient.parseJournalCsv(csvResp.data);
+  }
+
+  static parseJournalCsv(csv: string): FreeeJournalEntry[] {
+    const lines = csv.split('\n');
+    if (lines.length < 2) return [];
+
+    // Find header row (first non-empty line)
+    const headerLine = lines.find((l) => l.trim().length > 0);
+    if (!headerLine) return [];
+
+    const headers = FreeeClient.parseCsvLine(headerLine);
+
+    // Build column index map using known Japanese headers from freee generic format
+    const colMap: Record<string, number> = {};
+    const headerMappings: Record<string, string> = {
+      発生日: 'date',
+      仕訳番号: 'txn_number',
+      明細行: 'detail_number',
+      借方勘定科目: 'debit_account_item',
+      '借方金額(税込)': 'debit_amount',
+      借方金額: 'debit_amount',
+      貸方勘定科目: 'credit_account_item',
+      '貸方金額(税込)': 'credit_amount',
+      貸方金額: 'credit_amount',
+      摘要: 'description',
+      取引先: 'partner',
+      仕訳種別: 'source_type',
+    };
+
+    for (let i = 0; i < headers.length; i++) {
+      const mapped = headerMappings[headers[i]];
+      if (mapped && !(mapped in colMap)) {
+        colMap[mapped] = i;
+      }
+    }
+
+    const entries: FreeeJournalEntry[] = [];
+    const headerIdx = lines.indexOf(headerLine);
+
+    for (let i = headerIdx + 1; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+
+      const cols = FreeeClient.parseCsvLine(line);
+
+      const getCol = (key: string): string => {
+        const idx = colMap[key];
+        return idx !== undefined ? (cols[idx] ?? '').trim() : '';
+      };
+
+      const date = getCol('date');
+      if (!date) continue; // Skip rows without a date
+
+      entries.push({
+        date,
+        txn_number: getCol('txn_number'),
+        detail_number: getCol('detail_number'),
+        debit_account_item: getCol('debit_account_item'),
+        debit_amount: parseInt(getCol('debit_amount') || '0', 10) || 0,
+        credit_account_item: getCol('credit_account_item'),
+        credit_amount: parseInt(getCol('credit_amount') || '0', 10) || 0,
+        description: getCol('description') || undefined,
+        partner: getCol('partner') || undefined,
+        source_type: getCol('source_type') || undefined,
+      });
+    }
+
+    return entries;
+  }
+
+  private static parseCsvLine(line: string): string[] {
+    const fields: string[] = [];
+    let current = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (inQuotes) {
+        if (ch === '"') {
+          if (i + 1 < line.length && line[i + 1] === '"') {
+            current += '"';
+            i++;
+          } else {
+            inQuotes = false;
+          }
+        } else {
+          current += ch;
+        }
+      } else {
+        if (ch === '"') {
+          inQuotes = true;
+        } else if (ch === ',') {
+          fields.push(current);
+          current = '';
+        } else {
+          current += ch;
+        }
+      }
+    }
+    fields.push(current);
+    return fields;
   }
 
   // Note: Cash Flow Statement API (/reports/trial_cf) is not available in freee API

--- a/src/index.ts
+++ b/src/index.ts
@@ -1623,6 +1623,38 @@ registerTool(
   },
 );
 
+// === Journal tools (async download API) ===
+
+registerTool(
+  'freee_get_journals',
+  {
+    description:
+      'Get journal entries (仕訳帳) for a date range - Downloads all journal entries including deals, manual journals, and auto-generated entries. Uses async download API internally (request → poll → download). Ideal for monthly closing verification, anomaly detection (duplicate entries, unusual accounts), and comprehensive audit review. Returns structured data parsed from CSV. Note: may take 10-30 seconds for large date ranges.',
+    inputSchema: schemas.GetJournalsSchema,
+  },
+  async ({ companyId, startDate, endDate, visibleTags, visibleIds }) => {
+    try {
+      const entries = await freeeClient.getJournals(getCompanyId(companyId), {
+        start_date: startDate,
+        end_date: endDate,
+        visible_tags: visibleTags,
+        visible_ids: visibleIds,
+      });
+      const formatted = ResponseFormatter.formatJournalEntries(entries);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(formatted, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      handleToolError('freee_get_journals', error);
+    }
+  },
+);
+
 // === Resource handlers ===
 
 server.registerResource(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -561,6 +561,38 @@ export const ApproveExpenseApplicationSchema = {
     ),
 };
 
+// Journal schemas (async download API)
+export const GetJournalsSchema = {
+  companyId: companyIdField,
+  startDate: z.string().describe('Start date (YYYY-MM-DD)'),
+  endDate: z.string().describe('End date (YYYY-MM-DD)'),
+  visibleTags: z
+    .array(
+      z.enum([
+        'partner',
+        'item',
+        'tag',
+        'section',
+        'description',
+        'wallet_txn_description',
+        'all',
+        'segment_1_tag',
+        'segment_2_tag',
+        'segment_3_tag',
+      ]),
+    )
+    .optional()
+    .describe(
+      'Additional fields to include in output (partner, item, tag, section, description, all, etc.). Defaults to ["all"].',
+    ),
+  visibleIds: z
+    .array(z.enum(['deal_id', 'transfer_id', 'manual_journal_id']))
+    .optional()
+    .describe(
+      'Additional ID fields to include (deal_id, transfer_id, manual_journal_id)',
+    ),
+};
+
 // Tax Code schemas
 export const GetTaxCodesSchema = {
   companyId: companyIdField,

--- a/src/types/freee.ts
+++ b/src/types/freee.ts
@@ -269,6 +269,48 @@ export interface FreeeExpenseApplication {
   approval_flow_logs?: FreeeExpenseApplicationFlowLog[];
 }
 
+// Journal download types (async API)
+export interface FreeeJournalDownloadRequest {
+  id: number;
+  company_id: number;
+  download_type: 'generic' | 'generic_v2' | 'csv' | 'pdf';
+  encoding?: 'sjis' | 'utf-8' | null;
+  start_date?: string;
+  end_date?: string;
+  visible_tags?: string[];
+  visible_ids?: string[];
+  status_url: string;
+  up_to_date: boolean;
+  up_to_date_reasons?: Array<{
+    code: string;
+    message: string;
+  }>;
+  messages?: string[];
+}
+
+export interface FreeeJournalDownloadStatus {
+  id: number;
+  company_id: number;
+  download_type: string;
+  status: 'enqueued' | 'working' | 'uploaded' | 'failed';
+  start_date: string;
+  end_date: string;
+  download_url?: string;
+}
+
+export interface FreeeJournalEntry {
+  date: string;
+  txn_number: string;
+  detail_number: string;
+  debit_account_item: string;
+  debit_amount: number;
+  credit_account_item: string;
+  credit_amount: number;
+  description?: string;
+  partner?: string;
+  source_type?: string;
+}
+
 export interface FreeeApiError {
   status_code: number;
   errors: Array<{
@@ -440,6 +482,17 @@ export interface FormattedExpenseApplication {
   approvers?: FormattedExpenseApplicationApprover[];
   comments?: FormattedExpenseApplicationComment[];
   approval_flow_logs?: FormattedExpenseApplicationFlowLog[];
+}
+
+export interface FormattedJournalEntry {
+  date: string;
+  txn_number: string;
+  debit_account_item: string;
+  debit_amount: number;
+  credit_account_item: string;
+  credit_amount: number;
+  description?: string;
+  partner?: string;
 }
 
 export interface FormattedTransfer {


### PR DESCRIPTION
## Summary

- Add `freee_get_journals` tool that retrieves journal entries (仕訳帳) via freee's async download API
- Implements 3-step async pattern: request → poll status → download CSV
- Parses Japanese CSV headers into structured `FreeeJournalEntry` objects
- Supports date range filtering, visible tags, and visible IDs parameters

Closes #91

## Implementation Details

| File | Changes |
|------|---------|
| `src/types/freee.ts` | New types: `FreeeJournalDownloadRequest`, `FreeeJournalDownloadStatus`, `FreeeJournalEntry`, `FormattedJournalEntry` |
| `src/schemas.ts` | `GetJournalsSchema` with companyId, startDate, endDate, visibleTags, visibleIds |
| `src/api/freeeClient.ts` | `getJournals()` async method with polling + `parseJournalCsv()` CSV parser |
| `src/api/responseFormatter.ts` | `formatJournalEntry()`, `formatJournalEntries()`, `summarizeJournalEntries()` |
| `src/index.ts` | `freee_get_journals` tool registration |
| `src/__tests__/index.test.ts` | Updated tool/schema counts from 39 → 40 |

## Test plan

- [x] All 320 existing tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes (0 errors)
- [x] Build succeeds
- [x] Pre-commit hooks pass (eslint, typecheck, gitleaks)
- [ ] Manual: Test with real freee API for journal download

🤖 Generated with [Claude Code](https://claude.com/claude-code)