### PR TITLE
feat(schemas): add date format, offset, and amount validation

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8,18 +8,26 @@ const companyIdField = z
     'Company ID (optional, uses FREEE_DEFAULT_COMPANY_ID if not provided)',
   );
 
-const dateField = (description: string) =>
-  z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD format')
-    .describe(description);
+const yyyyMmDdDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD format')
+  .refine(
+    (val) => {
+      const [y, m, d] = val.split('-').map(Number);
+      const date = new Date(Date.UTC(y, m - 1, d));
+      return (
+        date.getUTCFullYear() === y &&
+        date.getUTCMonth() === m - 1 &&
+        date.getUTCDate() === d
+      );
+    },
+    { message: 'Date is not a valid calendar date' },
+  );
+
+const dateField = (description: string) => yyyyMmDdDate.describe(description);
 
 const optionalDateField = (description: string) =>
-  z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD format')
-    .optional()
-    .describe(description);
+  yyyyMmDdDate.optional().describe(description);
 
 // Auth schemas
 export const AuthorizeSchema = {


### PR DESCRIPTION
## Summary

- Create reusable `dateField`/`optionalDateField` helpers with `YYYY-MM-DD` regex validation, following existing `companyIdField` pattern
- Apply date validation to all 30 date fields across 16 schemas
- Add `.min(0)` to all 9 `offset` fields for pagination safety
- Add `.min(1)` to 4 monetary `amount` fields (aligning with `CreateManualJournalSchema` pattern)
- Add 121 unit tests covering validation edge cases

Closes #111

## Changes

| File | Change |
|---|---|
| `src/schemas.ts` | Add helpers, apply validations (60 insertions, 52 deletions) |
| `src/__tests__/schemas.test.ts` | New: 121 validation tests (603 lines) |

## Validation Details

**Date fields** (30 total): Regex `/^\d{4}-\d{2}-\d{2}$/` ensures YYYY-MM-DD format before API call. 7 required + 23 optional fields.

**Offset fields** (9 total): `.min(0)` prevents negative pagination offsets.

**Amount fields** (4 new + 1 existing): `.min(1)` on monetary transaction amounts (`CreateDealSchema`, `UpdateDealSchema`, `CreateDealPaymentSchema`, `CreateTransferSchema`). Filter fields (`minAmount`/`maxAmount`) intentionally excluded.

## Test plan

- [x] Invalid date formats rejected: `"not-a-date"`, `"2024/01/01"`, `""`, `"2024-1-1"`
- [x] Valid date format `"2024-01-15"` accepted
- [x] Optional date fields accept `undefined`
- [x] Negative offsets (`-1`) rejected, `0` accepted
- [x] Zero/negative amounts rejected, `1` accepted
- [x] Full integration tests with realistic payloads
- [x] All 455 tests pass (121 new + 334 existing)
- [x] Lint, typecheck, and build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)