### PR TITLE
chore(ci): slim down CI workflow to essential jobs only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,130 +7,29 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20.x
           cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Run linter
+      - name: Lint
         run: npm run lint
 
-      - name: Run type check
+      - name: Type check
         run: npm run typecheck
 
-      - name: Run tests
+      - name: Test
         run: npm test
-
-      - name: Run test coverage
-        run: npm run test:coverage
-
-      - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage/
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
 
       - name: Build
         run: npm run build
-
-  link-check:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Link Checker
-        uses: lycheeverse/lychee-action@v2
-        with:
-          # Check all markdown files
-          args: --verbose --no-progress './**/*.md'
-          fail: true
-
-      - name: Create Link Check Report
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: link-check-report
-          path: lychee-out.md
-
-  code-quality:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.x"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Check for security vulnerabilities
-        run: npm audit --audit-level=high
-
-      - name: Check for outdated dependencies
-        run: npx npm-check-updates --errorLevel 2
-        continue-on-error: true
-
-      - name: License checker
-        run: npx license-checker --onlyAllow 'MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Unlicense;Python-2.0' --excludePackages 'argparse'
-        continue-on-error: true
-
-  security-scan:
-    runs-on: ubuntu-latest
-    name: Security Scan (Gitleaks)
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Full history for gitleaks
-
-      - name: Run Gitleaks
-        id: gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }} # Optional: for Gitleaks Pro
-
-      - name: Upload Gitleaks SARIF report
-        if: failure()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
-
-      - name: Upload Gitleaks results as artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: gitleaks-results
-          path: |
-            results.sarif
-            results.json
-          retention-days: 30


### PR DESCRIPTION
## Summary

- Remove `link-check`, `code-quality`, and `security-scan` jobs from CI workflow
- Remove Codecov upload and coverage artifact steps
- Retain only lint, typecheck, test, and build as sequential steps in a single streamlined job
- Inline Node.js version (20.x) instead of using a single-element matrix

## Rationale

| Removed Job | Reason |
|---|---|
| `link-check` | Fails on transient external URL issues, not related to code correctness |
| `code-quality` | `npm audit` fails on transitive vulnerabilities; `npm-check-updates` and `license-checker` were already `continue-on-error` |
| `security-scan` (Gitleaks) | Already enforced by pre-commit hook via lint-staged |
| Codecov upload | Adds flaky external dependency without actionable value |

## What stays

The 4 essential checks that gate code correctness:
1. `npm run lint` — ESLint
2. `npm run typecheck` — TypeScript
3. `npm test` — Jest
4. `npm run build` — Compile check

## Test plan

- [x] `npm run lint` passes (0 errors)
- [x] `npm run typecheck` passes
- [x] `npm test` passes (505/509, 4 pre-existing failures unrelated to CI changes)
- [x] `npm run build` passes
- [x] Workflow YAML is syntactically valid
- [x] Pre-commit hook with Gitleaks still enforced locally (verified during commit)
- [ ] CI pipeline runs successfully on this PR

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)