### PR TITLE
feat(skill): add /freee-setup Claude Code skill for setup automation

### DIFF
--- a/skills/freee-setup/skill.md
+++ b/skills/freee-setup/skill.md
@@ -215,7 +215,7 @@ If `INVALID`, display error and instruct user to check the config file manually.
 Read the config file and display the freee section:
 
 ```bash
-jq '.mcpServers.freee' "$CONFIG_PATH"
+jq '.mcpServers.freee | .env.FREEE_CLIENT_SECRET = "***" | .env.FREEE_TOKEN_ENCRYPTION_KEY = "***"' "$CONFIG_PATH"
 ```
 
 Then display the completion message:


### PR DESCRIPTION
## Summary

- Add interactive Claude Code skill (`/freee-setup`) that automates the 4-step manual freee-mcp configuration for Claude Desktop
- Create `setup.sh` helper script for safe JSON config manipulation via `jq` with atomic writes and temp file cleanup
- Support both `npx` and local-build installation modes with OS-aware config path detection (macOS/Linux/Windows)

Closes #128

## Implementation Details

### New Files

| File | Purpose |
|------|---------|
| `skills/freee-setup/skill.md` | Skill definition with interactive 9-step wizard workflow |
| `skills/freee-setup/setup.sh` | Bash helper for config detection, key generation, JSON manipulation |

### `setup.sh` Actions

| Action | Description |
|--------|-------------|
| `detect-config` | Print platform-specific `claude_desktop_config.json` path |
| `check-jq` | Verify `jq` availability |
| `check-existing` | Check if freee entry already exists in config |
| `generate-key` | Generate 64-char hex AES-256 encryption key |
| `update-config` | Add/update freee entry preserving existing MCP servers |
| `validate` | Validate resulting JSON is well-formed |

### Key Design Decisions

- **Atomic writes**: Temp files created in same directory as config for same-filesystem `mv`
- **jq safety**: All user inputs passed via `--arg`/`--argjson` (no shell interpolation into JSON)
- **Idempotent**: Running update-config twice replaces the entry without duplication
- **Correct env var**: Uses `FREEE_TOKEN_ENCRYPTION_KEY` (matching codebase, not issue template)
- **Correct redirect URI**: Uses `urn:ietf:wg:oauth:2.0:oob` (matching setup-auth.js)

## Test plan

- [x] `detect-config` returns correct macOS path
- [x] `check-jq` returns success when jq installed
- [x] `generate-key` produces 64-char hex string
- [x] `update-config` (npx mode) creates correct JSON structure
- [x] `update-config` (local mode) uses node command with local path
- [x] `update-config` preserves existing MCP server entries
- [x] `update-config` creates config from scratch (missing file/dir)
- [x] Idempotent: running twice doesn't duplicate entries
- [x] `validate` correctly identifies valid/invalid JSON
- [x] `skill.md` has `user-invocable: true` frontmatter
- [x] No secrets hardcoded in either file
- [x] Existing project tests pass (509 tests, 0 failures)
- [x] Lint and typecheck pass
- [x] Gitleaks: no secrets detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)