### PR TITLE
refactor(schema): migrate tool registration to Zod 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "1.14.0",
         "debug": "^4.4.3",
         "dotenv": "^16.5.0",
-        "zod": "^3.25.28"
+        "zod": "^4.3.6"
       },
       "bin": {
         "freee-mcp": "dist/index.js"
@@ -7718,9 +7718,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.28",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
-      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "axios": "1.14.0",
     "debug": "^4.4.3",
     "dotenv": "^16.5.0",
-    "zod": "^3.25.28"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -34,6 +34,10 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
       );
     });
 
+    it('should use Zod v4 in package.json', () => {
+      expect(packageJson.dependencies.zod).toMatch(/^\^4\./);
+    });
+
     it('should import McpServer from @modelcontextprotocol/sdk/server/mcp.js', () => {
       expect(indexSource).toMatch(
         /from ['"]@modelcontextprotocol\/sdk\/server\/mcp\.js['"]/,
@@ -167,10 +171,13 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
       expect(toolNames).not.toContain('freee_get_cash_flow');
     });
 
-    it('should use non-generic registerTool wrapper to avoid TS2589', () => {
-      // Verify the workaround function exists
-      expect(indexSource).toContain('function registerTool(');
-      expect(indexSource).toContain('(server as any).registerTool(');
+    it('should use typed registerTool wrapper without any casts', () => {
+      expect(indexSource).toContain(
+        'function registerTool<InputSchema extends z.ZodRawShape | undefined>(',
+      );
+      expect(indexSource).toContain('handler: ToolCallback<InputSchema>');
+      expect(indexSource).toContain('server.registerTool(name, config, handler);');
+      expect(indexSource).not.toContain('(server as any).registerTool(');
     });
 
     it('should register each tool with description', () => {
@@ -643,9 +650,9 @@ describe('Build & Quality Verification', () => {
     expect(indexSource).not.toContain('CashFlow');
   });
 
-  it('should use CallToolResult type from SDK types', () => {
-    expect(indexSource).toContain('CallToolResult');
-    expect(indexSource).toContain('type CallToolResult');
+  it('should use ToolCallback type from MCP server SDK', () => {
+    expect(indexSource).toContain('ToolCallback');
+    expect(indexSource).toContain('type ToolCallback');
   });
 });
 

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -20,6 +20,8 @@ import {
   SummarizeInvoicesSchema,
 } from '../schemas.js';
 
+type RawSchema = z.ZodRawShape;
+
 /**
  * Tests for Issue #111: date format, offset, and amount validations in schemas.
  *
@@ -108,7 +110,7 @@ describe('dateField validation', () => {
 describe('dateField applied to multiple schemas', () => {
   const dateFieldCases: {
     schemaName: string;
-    schema: Record<string, z.ZodTypeAny>;
+    schema: RawSchema;
     field: string;
   }[] = [
     {
@@ -150,7 +152,7 @@ describe('dateField applied to multiple schemas', () => {
 
   describe.each(dateFieldCases)('$schemaName.$field', ({ schema, field }) => {
     const wrapped = z.object({
-      [field]: (schema as Record<string, z.ZodTypeAny>)[field],
+      [field]: schema[field],
     });
 
     it('should reject invalid format "2024/01/01"', () => {
@@ -216,7 +218,7 @@ describe('optionalDateField validation', () => {
 describe('optionalDateField applied to multiple schemas', () => {
   const optionalDateFieldCases: {
     schemaName: string;
-    schema: Record<string, z.ZodTypeAny>;
+    schema: RawSchema;
     field: string;
   }[] = [
     {
@@ -290,7 +292,7 @@ describe('optionalDateField applied to multiple schemas', () => {
     '$schemaName.$field',
     ({ schema, field }) => {
       const wrapped = z.object({
-        [field]: (schema as Record<string, z.ZodTypeAny>)[field],
+        [field]: schema[field],
       });
 
       it('should allow undefined', () => {
@@ -316,7 +318,7 @@ describe('optionalDateField applied to multiple schemas', () => {
 describe('offset field validation (.min(0))', () => {
   const offsetCases: {
     schemaName: string;
-    schema: Record<string, z.ZodTypeAny>;
+    schema: RawSchema;
   }[] = [
     { schemaName: 'GetDealsSchema', schema: GetDealsSchema },
     { schemaName: 'GetPartnersSchema', schema: GetPartnersSchema },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,12 @@
 import {
   McpServer,
   ResourceTemplate,
+  type ToolCallback,
 } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   McpError,
   ErrorCode,
-  type CallToolResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { readFileSync } from 'node:fs';
 import createDebug from 'debug';
@@ -124,18 +124,14 @@ function formatError(error: unknown): string {
   return String(error);
 }
 
-// Workaround for TS2589: cumulative registerTool calls with complex Zod schemas
-// exceed TypeScript's type instantiation depth limit due to Zod v3/v4 dual type inference.
-// This non-generic wrapper breaks the inference chain while preserving runtime validation.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function registerTool(
+// Keep a local wrapper so tool registrations stay consistent in one place, but
+// let Zod 4's lighter types carry the actual schema and handler inference.
+function registerTool<InputSchema extends z.ZodRawShape | undefined>(
   name: string,
-  config: { description: string; inputSchema?: Record<string, z.ZodTypeAny> },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handler: (args: any) => Promise<CallToolResult>,
+  config: { description: string; inputSchema?: InputSchema },
+  handler: ToolCallback<InputSchema>,
 ): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (server as any).registerTool(name, config, handler);
+  server.registerTool(name, config, handler);
 }
 
 // Helper to handle tool errors with logging


### PR DESCRIPTION
## Summary
- upgrade  from  to  and refresh the lockfile
- replace the -based  shim with a typed generic wrapper while keeping tool names and input argument names unchanged
- update focused regression tests for the new Zod v4 package version and raw schema shape typing

## Verification
- 
> freee-mcp@0.1.0 test
> jest ✅
- 
> freee-mcp@0.1.0 build
> tsc ✅
- 
> freee-mcp@0.1.0 lint
> eslint src --ext .ts


/private/tmp/freee-mcp-issue-174/src/__tests__/api/analysis.test.ts
  43:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  44:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/private/tmp/freee-mcp-issue-174/src/__tests__/api/freeeClient.test.ts
    50:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
    51:30  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
    52:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1198:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1219:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1234:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1236:45  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1239:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1243:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1253:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1257:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1261:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1262:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1266:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1267:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1268:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1272:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1274:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1277:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1281:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1286:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1290:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1306:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1326:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1342:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1364:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1377:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1411:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1449:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1486:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1533:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1563:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1632:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/private/tmp/freee-mcp-issue-174/src/__tests__/api/pagination.test.ts
  13:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  14:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/private/tmp/freee-mcp-issue-174/src/__tests__/api/segmentPnl.test.ts
  43:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  44:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/private/tmp/freee-mcp-issue-174/src/__tests__/clearAuth.test.ts
  7:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/private/tmp/freee-mcp-issue-174/src/__tests__/costAnalysis.test.ts
  133:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  208:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  263:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  297:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  333:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  369:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  416:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/private/tmp/freee-mcp-issue-174/src/__tests__/handlers.test.ts
   11:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   12:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   96:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  104:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/private/tmp/freee-mcp-issue-174/src/__tests__/scripts/setup-auth.test.ts
  198:23  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 52 problems (0 errors, 52 warnings) ✅ (existing warning-only  findings remain in unrelated test files)

Closes #174