### PR TITLE
feat(kpi): add structured dashboard output

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ Parameters:
 
 Aggregating operating profit from individual deals can require thousands of API calls and significant client-side processing. The `freee_get_profit_loss` tool returns pre-aggregated report data in a single request, which dramatically reduces rate-limit usage. For most reporting flows, start with report APIs and only fetch raw deals when you need detailed drill-down.
 
+The `freee_kpi_dashboard` tool is the first structured output PoC: it keeps the existing text response for current clients and also returns `structuredContent` with the company, period, and profitability / safety / efficiency / liquidity KPI sections for UI and automation use.
+
 Tip: Set `FREEE_DEFAULT_COMPANY_ID` so report calls work without passing `companyId` each time.
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "1.14.0",
         "debug": "^4.4.3",
         "dotenv": "^16.5.0",
@@ -1616,9 +1616,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "npm": ">=9.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "1.14.0",
     "debug": "^4.4.3",
     "dotenv": "^16.5.0",

--- a/src/__tests__/api/responseFormatter.test.ts
+++ b/src/__tests__/api/responseFormatter.test.ts
@@ -10,6 +10,7 @@ import type {
   FreeeTag,
   FreeeTransfer,
   FreeeSegmentTag,
+  KpiDashboardResult,
 } from '../../types/freee.js';
 
 // --- Test Data Factories ---
@@ -162,6 +163,56 @@ function makeSegmentTag(overrides?: Partial<FreeeSegmentTag>): FreeeSegmentTag {
 // --- Tests ---
 
 describe('ResponseFormatter', () => {
+  describe('formatKpiDashboardStructured', () => {
+    it('should add company and period identifiers while preserving KPI sections', () => {
+      const dashboard: KpiDashboardResult = {
+        fiscal_year: 2024,
+        start_month: 1,
+        end_month: 12,
+        profitability: [
+          { label: '売上高', value: 10000000, unit: '円' },
+          { label: '営業利益率', value: 20, unit: '%', status: 'healthy' },
+        ],
+        safety: [
+          { label: '流動比率', value: 200, unit: '%', status: 'healthy' },
+        ],
+        efficiency: [
+          { label: '売上債権回転日数', value: 44, unit: '日', status: 'caution' },
+        ],
+        liquidity: [{ label: '運転資本', value: 2500000, unit: '円' }],
+        summary: '全指標健全',
+      };
+
+      const result = ResponseFormatter.formatKpiDashboardStructured(
+        123,
+        dashboard,
+      );
+
+      expect(result).toEqual({
+        company_id: 123,
+        period: {
+          fiscal_year: 2024,
+          start_month: 1,
+          end_month: 12,
+        },
+        profitability: [
+          { label: '売上高', value: 10000000, unit: '円', status: 'neutral' },
+          { label: '営業利益率', value: 20, unit: '%', status: 'healthy' },
+        ],
+        safety: [
+          { label: '流動比率', value: 200, unit: '%', status: 'healthy' },
+        ],
+        efficiency: [
+          { label: '売上債権回転日数', value: 44, unit: '日', status: 'caution' },
+        ],
+        liquidity: [
+          { label: '運転資本', value: 2500000, unit: '円', status: 'neutral' },
+        ],
+        summary: '全指標健全',
+      });
+    });
+  });
+
   // =============================================
   // Deal Formatting
   // =============================================

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -28,9 +28,9 @@ const packageJson = JSON.parse(
 
 describe('MCP SDK 1.x Migration - index.ts', () => {
   describe('MCP SDK Version', () => {
-    it('should use MCP SDK ^1.26.0 in package.json', () => {
+    it('should use MCP SDK ^1.29.0 in package.json', () => {
       expect(packageJson.dependencies['@modelcontextprotocol/sdk']).toBe(
-        '^1.26.0',
+        '^1.29.0',
       );
     });
 
@@ -278,6 +278,26 @@ describe('MCP SDK 1.x Migration - index.ts', () => {
       expect(companiesBlock).toBeDefined();
       // It should NOT have inputSchema
       expect(companiesBlock![0]).not.toContain('inputSchema');
+    });
+
+    it('should return structuredContent for freee_kpi_dashboard without changing text content', () => {
+      const kpiNameStart = indexSource.indexOf('freee_kpi_dashboard');
+      const kpiStart = indexSource.lastIndexOf(
+        'registerTool(',
+        kpiNameStart,
+      );
+      const resourceStart = indexSource.indexOf('// === Resource handlers ===');
+      const kpiBlock = indexSource.slice(kpiStart, resourceStart);
+
+      expect(kpiNameStart).toBeGreaterThan(-1);
+      expect(kpiStart).toBeGreaterThan(-1);
+      expect(resourceStart).toBeGreaterThan(kpiStart);
+      expect(kpiBlock).toContain('text: JSON.stringify(result, null, 2)');
+      expect(kpiBlock).toContain('structuredContent:');
+      expect(kpiBlock).toContain(
+        'ResponseFormatter.formatKpiDashboardStructured',
+      );
+      expect(kpiBlock).toContain('resolvedCompanyId');
     });
   });
 

--- a/src/api/responseFormatter.ts
+++ b/src/api/responseFormatter.ts
@@ -39,6 +39,10 @@ import type {
   FormattedExpenseApplicationFlowLog,
   ListSummary,
   FormattedListResponse,
+  KpiDashboardResult,
+  KpiDashboardStructuredContent,
+  KpiMetric,
+  KpiStructuredMetric,
 } from '../types/freee.js';
 
 /**
@@ -55,6 +59,33 @@ function stripEmpty<T extends Record<string, unknown>>(obj: T): Partial<T> {
 }
 
 export class ResponseFormatter {
+  static formatKpiDashboardStructured(
+    companyId: number,
+    result: KpiDashboardResult,
+  ): KpiDashboardStructuredContent {
+    const addDefaultStatus = (metrics: KpiMetric[]): KpiStructuredMetric[] =>
+      metrics.map((metric) => ({
+        label: metric.label,
+        value: metric.value,
+        unit: metric.unit,
+        status: metric.status ?? 'neutral',
+      }));
+
+    return {
+      company_id: companyId,
+      period: {
+        fiscal_year: result.fiscal_year,
+        start_month: result.start_month,
+        end_month: result.end_month,
+      },
+      profitability: addDefaultStatus(result.profitability),
+      safety: addDefaultStatus(result.safety),
+      efficiency: addDefaultStatus(result.efficiency),
+      liquidity: addDefaultStatus(result.liquidity),
+      summary: result.summary,
+    };
+  }
+
   // Deal formatting
   static formatDeal(deal: FreeeDeal): FormattedDeal {
     const detail: FormattedDealDetail[] = (deal.details ?? []).map((d) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2512,8 +2512,9 @@ registerTool(
   },
   async ({ companyId, fiscalYear, startMonth, endMonth }) => {
     try {
+      const resolvedCompanyId = getCompanyId(companyId);
       const result = await freeeClient.getKpiDashboard(
-        getCompanyId(companyId),
+        resolvedCompanyId,
         {
           fiscal_year: fiscalYear,
           start_month: startMonth,
@@ -2527,6 +2528,10 @@ registerTool(
             text: JSON.stringify(result, null, 2),
           },
         ],
+        structuredContent: ResponseFormatter.formatKpiDashboardStructured(
+          resolvedCompanyId,
+          result,
+        ),
       };
     } catch (error) {
       handleToolError('freee_kpi_dashboard', error);

--- a/src/types/freee.ts
+++ b/src/types/freee.ts
@@ -1015,6 +1015,7 @@ export interface ItemSuggestionResult {
 // KPI Dashboard types
 
 export type KpiStatus = 'healthy' | 'caution' | 'warning';
+export type KpiStructuredStatus = KpiStatus | 'neutral';
 
 export interface KpiMetric {
   label: string;
@@ -1033,6 +1034,27 @@ export interface KpiDashboardResult {
   liquidity: KpiMetric[];
   summary: string;
 }
+
+export interface KpiStructuredMetric {
+  label: string;
+  value: number;
+  unit: string;
+  status: KpiStructuredStatus;
+}
+
+export type KpiDashboardStructuredContent = Record<string, unknown> & {
+  company_id: number;
+  period: {
+    fiscal_year: number;
+    start_month: number;
+    end_month: number;
+  };
+  profitability: KpiStructuredMetric[];
+  safety: KpiStructuredMetric[];
+  efficiency: KpiStructuredMetric[];
+  liquidity: KpiStructuredMetric[];
+  summary: string;
+};
 
 // AR Aging types
 


### PR DESCRIPTION
## Summary
- Upgrade @modelcontextprotocol/sdk to ^1.29.0.
- Return structuredContent from freee_kpi_dashboard with company_id, period, and profitability / safety / efficiency / liquidity KPI sections while preserving the existing JSON text content.
- Add formatter coverage, source-level handler verification, and a README note for the PoC.

## Verification
- npm run typecheck
- npm test
- npm run build
- npm run lint (passes with existing no-explicit-any warnings in tests)
- gitleaks detect --source . --verbose --no-banner --redact

## Notes
- npm install reported 11 audit findings; dependency remediation beyond the MCP SDK upgrade is left out of this issue scope.

Resolves #177